### PR TITLE
code language could also be from the headers just like code-line-numbers

### DIFF
--- a/lib/slideshow/helpers/syntax/sh_helper.rb
+++ b/lib/slideshow/helpers/syntax/sh_helper.rb
@@ -8,7 +8,7 @@ module Slideshow
 
 def sh_worker( code, opts )
   
-  lang         = opts.fetch( :lang, SH_LANG )  
+  lang         = opts.fetch( :lang, headers.get( 'code-language', SH_LANG ))
   line_numbers_value = opts.fetch( :line_numbers, headers.get( 'code-line-numbers', SH_LINE_NUMBERS ))
   line_numbers = (line_numbers_value =~ /true|yes|on/i) ? true : false
      


### PR DESCRIPTION
code-language header support would be cool. Please see if this small change is useful. I am not sure where else to change since I see there is support for other syntax highlighters.
