### PR TITLE
Fix for utf-8 issue

### DIFF
--- a/lib/slideshow/filters/debug_filter.rb
+++ b/lib/slideshow/filters/debug_filter.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Slideshow
   module DebugFilter
 

--- a/lib/slideshow/filters/headers_filter.rb
+++ b/lib/slideshow/filters/headers_filter.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Slideshow
   module HeadersFilter
 

--- a/lib/slideshow/filters/slide_filter.rb
+++ b/lib/slideshow/filters/slide_filter.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Slideshow
   module SlideFilter
 

--- a/lib/slideshow/filters/text_filter.rb
+++ b/lib/slideshow/filters/text_filter.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # builtin text filters
 # called before text_to_html
 #


### PR DESCRIPTION
Thanks for slideshow, very useful.

It would be great if tests/specs were added, though. In the meantime, here's a shell script to illustrate the issue:

```
echo "<%= include 'intro.textile' %>" > main.textile
echo "Marc-André" > intro.textile
slideshow main.textile

# => /Users/mal/.rvm/gems/ruby-1.9.3-p0/gems/slideshow-0.9.9/lib/slideshow/filters/text_filter.rb:309:in `gsub!': invalid byte sequence in US-ASCII (ArgumentError)
```

Problem are the filters that start from scratch instead of the given content; the "" has the encoding of the current source file, which defaults to ASCII. This creates problems down the line when UTF-8 text is inserted.

Fix is trivial, just add the magic comment to specify utf-8 encoding.

Thanks.
